### PR TITLE
Switch to using async/await in the implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/shogowada/json-rpc-2.0/issues"
   },
   "homepage": "https://github.com/shogowada/json-rpc-2.0#readme",
+  "engines": {
+    "node": ">=0.8"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^8.2.0",

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -22,7 +22,7 @@ describe("JSONRPCClient", () => {
     reject = undefined;
 
     client = new JSONRPCClient(
-      request => clientParams => {
+      (request, clientParams) => {
         lastRequest = request;
         lastClientParams = clientParams;
         return new Promise((givenResolve, givenReject) => {
@@ -43,12 +43,10 @@ describe("JSONRPCClient", () => {
       result = undefined;
       error = undefined;
 
-      promise = client
-        .request("foo", ["bar"])
-        .then(
-          givenResult => (result = givenResult),
-          givenError => (error = givenError)
-        );
+      promise = client.request("foo", ["bar"]).then(
+        (givenResult) => (result = givenResult),
+        (givenError) => (error = givenError)
+      );
     });
 
     it("should send the request", () => {
@@ -56,7 +54,7 @@ describe("JSONRPCClient", () => {
         jsonrpc: JSONRPC,
         id,
         method: "foo",
-        params: ["bar"]
+        params: ["bar"],
       });
     });
 
@@ -72,7 +70,7 @@ describe("JSONRPCClient", () => {
           response = {
             jsonrpc: JSONRPC,
             id,
-            result: "foo"
+            result: "foo",
           };
 
           client.receive(response);
@@ -90,7 +88,7 @@ describe("JSONRPCClient", () => {
           client.receive({
             jsonrpc: JSONRPC,
             id,
-            result: 0
+            result: 0,
           });
 
           return promise;
@@ -110,8 +108,8 @@ describe("JSONRPCClient", () => {
             id,
             error: {
               code: 0,
-              message: "This is a test. Do not panic."
-            }
+              message: "This is a test. Do not panic.",
+            },
           };
 
           client.receive(response);
@@ -135,8 +133,8 @@ describe("JSONRPCClient", () => {
               result: "foo",
               error: {
                 code: 0,
-                message: "bar"
-              }
+                message: "bar",
+              },
             };
 
             client.receive(response);
@@ -155,7 +153,7 @@ describe("JSONRPCClient", () => {
           beforeEach(() => {
             response = {
               jsonrpc: JSONRPC,
-              id
+              id,
             };
 
             client.receive(response);
@@ -189,7 +187,7 @@ describe("JSONRPCClient", () => {
             client.receive({
               jsonrpc: JSONRPC,
               id,
-              result: "foo"
+              result: "foo",
             });
 
             return promise;
@@ -265,7 +263,7 @@ describe("JSONRPCClient", () => {
       expect(lastRequest).to.deep.equal({
         jsonrpc: JSONRPC,
         method: "foo",
-        params: ["bar"]
+        params: ["bar"],
       });
     });
   });

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -4,7 +4,7 @@ import {
   isJSONRPCRequest,
   isJSONRPCResponse,
   JSONRPCParams,
-  JSONRPCResponse
+  JSONRPCResponse,
 } from "./models";
 
 export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
@@ -13,7 +13,7 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     public client: JSONRPCClient<ClientParams>
   ) {}
 
-  addMethod(name: string, method: SimpleJSONRPCMethod): void {
+  addMethod(name: string, method: SimpleJSONRPCMethod<ServerParams>): void {
     this.server.addMethod(name, method);
   }
 

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -32,7 +32,7 @@ describe("JSONRPCServer", () => {
     beforeEach(() => {
       server.addMethod(
         "echo",
-        ({ text }: Params) => (serverParams?: ServerParams) => {
+        ({ text }: Params, serverParams?: ServerParams) => {
           if (serverParams) {
             return `${serverParams.userID} said ${text}`;
           } else {
@@ -49,16 +49,16 @@ describe("JSONRPCServer", () => {
             jsonrpc: JSONRPC,
             id: 0,
             method: "echo",
-            params: { text: "foo" }
+            params: { text: "foo" },
           })
-          .then(givenResponse => (response = givenResponse));
+          .then((givenResponse) => (response = givenResponse));
       });
 
       it("should echo the text", () => {
         expect(response).to.deep.equal({
           jsonrpc: JSONRPC,
           id: 0,
-          result: "foo"
+          result: "foo",
         });
       });
     });
@@ -71,18 +71,18 @@ describe("JSONRPCServer", () => {
               jsonrpc: JSONRPC,
               id: 0,
               method: "echo",
-              params: { text: "foo" }
+              params: { text: "foo" },
             },
             { userID: "bar" }
           )
-          .then(givenResponse => (response = givenResponse));
+          .then((givenResponse) => (response = givenResponse));
       });
 
       it("should echo the text with the user ID", () => {
         expect(response).to.deep.equal({
           jsonrpc: JSONRPC,
           id: 0,
-          result: "bar said foo"
+          result: "bar said foo",
         });
       });
     });
@@ -94,14 +94,14 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "ack" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should response with null result", () => {
       expect(response).to.deep.equal({
         jsonrpc: JSONRPC,
         id: 0,
-        result: null
+        result: null,
       });
     });
   });
@@ -114,7 +114,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "throw" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -123,8 +123,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: 0,
-          message: "Test throwing"
-        }
+          message: "Test throwing",
+        },
       });
     });
   });
@@ -137,7 +137,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "reject" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -146,8 +146,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: 0,
-          message: "Test rejecting"
-        }
+          message: "Test rejecting",
+        },
       });
     });
   });
@@ -158,7 +158,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, method: "foo" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should not respond", () => {
@@ -172,7 +172,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, method: "foo" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should not respond", () => {
@@ -188,9 +188,9 @@ describe("JSONRPCServer", () => {
         .receive({
           jsonrpc: JSONRPC,
           id: 0,
-          method: "foo"
+          method: "foo",
         })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -199,8 +199,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: JSONRPCErrorCode.InternalError,
-          message: "Internal error"
-        }
+          message: "Internal error",
+        },
       });
     });
   });
@@ -211,9 +211,9 @@ describe("JSONRPCServer", () => {
         .receive({
           jsonrpc: JSONRPC,
           id: 0,
-          method: "foo"
+          method: "foo",
         })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -222,8 +222,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: JSONRPCErrorCode.MethodNotFound,
-          message: "Method not found"
-        }
+          message: "Method not found",
+        },
       });
     });
   });


### PR DESCRIPTION
Again, another change that you should feel free to take or leave, but I think it'd be a bit clearer to use `async`/`await` syntax in the implementations for a bit less syntactic noise as well as better performance on recent node versions that have promises built into the VM. 

This is on top of #13 but I am happy to rebase if you would like to land it separately! 