### PR TITLE
Allow servers to set and clients to receive data with errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.7.1.tgz",
-      "integrity": "sha512-EGoI4ylB/lPOaqXqtzAyL8HcgOuCtH2hkEaLmkueOYufsTFWBn4VCvlCDC2HW8Q+9iF+QVC3sxjDKQYjHQeZ9w==",
+      "version": "14.14.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.16.tgz",
+      "integrity": "sha512-naXYePhweTi+BMv11TgioE2/FXU4fSl29HAH1ffxVciNsH3rYXjNP2yM8wqmSm7jS20gM8TIklKiTen+1iVncw==",
       "dev": true
     },
     "@ungap/promise-all-settled": {
@@ -2018,9 +2018,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "url": "https://github.com/shogowada/json-rpc-2.0/issues"
   },
   "homepage": "https://github.com/shogowada/json-rpc-2.0#readme",
+  "engines": {
+    "node": ">=0.8"
+  },
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/mocha": "^8.2.0",
-    "@types/node": "^10.7.1",
+    "@types/node": "^14.14.16",
     "chai": "^4.1.2",
     "del-cli": "^1.1.0",
     "mocha": "^8.2.1",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
     "ts-node": "^7.0.1",
-    "typescript": "^2.9.2"
+    "typescript": "^4.1.0"
   }
 }

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -22,7 +22,7 @@ describe("JSONRPCClient", () => {
     reject = undefined;
 
     client = new JSONRPCClient(
-      request => clientParams => {
+      (request, clientParams) => {
         lastRequest = request;
         lastClientParams = clientParams;
         return new Promise((givenResolve, givenReject) => {
@@ -43,12 +43,10 @@ describe("JSONRPCClient", () => {
       result = undefined;
       error = undefined;
 
-      promise = client
-        .request("foo", ["bar"])
-        .then(
-          givenResult => (result = givenResult),
-          givenError => (error = givenError)
-        );
+      promise = client.request("foo", ["bar"]).then(
+        (givenResult) => (result = givenResult),
+        (givenError) => (error = givenError)
+      );
     });
 
     it("should send the request", () => {
@@ -56,7 +54,7 @@ describe("JSONRPCClient", () => {
         jsonrpc: JSONRPC,
         id,
         method: "foo",
-        params: ["bar"]
+        params: ["bar"],
       });
     });
 
@@ -72,7 +70,7 @@ describe("JSONRPCClient", () => {
           response = {
             jsonrpc: JSONRPC,
             id,
-            result: "foo"
+            result: "foo",
           };
 
           client.receive(response);
@@ -90,7 +88,7 @@ describe("JSONRPCClient", () => {
           client.receive({
             jsonrpc: JSONRPC,
             id,
-            result: 0
+            result: 0,
           });
 
           return promise;
@@ -110,8 +108,8 @@ describe("JSONRPCClient", () => {
             id,
             error: {
               code: 0,
-              message: "This is a test. Do not panic."
-            }
+              message: "This is a test. Do not panic.",
+            },
           };
 
           client.receive(response);
@@ -135,8 +133,8 @@ describe("JSONRPCClient", () => {
               result: "foo",
               error: {
                 code: 0,
-                message: "bar"
-              }
+                message: "bar",
+              },
             };
 
             client.receive(response);
@@ -155,7 +153,7 @@ describe("JSONRPCClient", () => {
           beforeEach(() => {
             response = {
               jsonrpc: JSONRPC,
-              id
+              id,
             };
 
             client.receive(response);
@@ -189,7 +187,7 @@ describe("JSONRPCClient", () => {
             client.receive({
               jsonrpc: JSONRPC,
               id,
-              result: "foo"
+              result: "foo",
             });
 
             return promise;
@@ -265,7 +263,7 @@ describe("JSONRPCClient", () => {
       expect(lastRequest).to.deep.equal({
         jsonrpc: JSONRPC,
         method: "foo",
-        params: ["bar"]
+        params: ["bar"],
       });
     });
   });

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -1,6 +1,12 @@
 import { describe, beforeEach, it } from "mocha";
 import { expect } from "chai";
-import { JSONRPCClient, JSONRPC, JSONRPCResponse, JSONRPCRequest } from ".";
+import {
+  JSONRPCClient,
+  JSONRPC,
+  JSONRPCResponse,
+  JSONRPCRequest,
+  JSONRPCRemoteError,
+} from ".";
 
 interface ClientParams {
   token: string;
@@ -109,6 +115,9 @@ describe("JSONRPCClient", () => {
             error: {
               code: 0,
               message: "This is a test. Do not panic.",
+              data: {
+                test: true,
+              },
             },
           };
 
@@ -119,6 +128,8 @@ describe("JSONRPCClient", () => {
 
         it("should reject with the error message", () => {
           expect(error.message).to.equal(response.error!.message);
+          expect(error.code).to.equal(0);
+          expect(error.data.test).to.equal(true);
         });
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,17 @@ type Resolve = (response: JSONRPCResponse) => void;
 
 type IDToDeferredMap = Map<JSONRPCID, Resolve>;
 
+export class JSONRPCRemoteError extends Error {
+  constructor(
+    message: string,
+    readonly code: number,
+    readonly response?: JSONRPCResponse,
+    readonly data?: any
+  ) {
+    super(message);
+  }
+}
+
 export class JSONRPCClient<ClientParams = void> {
   private idToResolveMap: IDToDeferredMap;
   private id: number;
@@ -55,7 +66,12 @@ export class JSONRPCClient<ClientParams = void> {
     if (response.result !== undefined && !response.error) {
       return response.result;
     } else if (response.result === undefined && response.error) {
-      throw new Error(response.error.message);
+      throw new JSONRPCRemoteError(
+        response.error.message,
+        response.error.code,
+        response,
+        response.error.data
+      );
     } else {
       throw new Error("An unexpected error occurred");
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -46,20 +46,27 @@ export enum JSONRPCErrorCode {
   InvalidRequest = -32600,
   MethodNotFound = -32601,
   InvalidParams = -32602,
-  InternalError = -32603
+  InternalError = -32603,
 }
 
 export const createJSONRPCErrorResponse = (
   id: JSONRPCID,
   code: number,
-  message: string
+  message: string,
+  data?: any
 ): JSONRPCResponse => {
-  return {
+  const errorResponse: JSONRPCResponse = {
     jsonrpc: JSONRPC,
     id,
     error: {
       code,
-      message
-    }
+      message,
+    },
   };
+
+  if (data) {
+    errorResponse.error!.data = data;
+  }
+
+  return errorResponse;
 };

--- a/src/server-and-client.spec.ts
+++ b/src/server-and-client.spec.ts
@@ -71,9 +71,10 @@ describe("JSONRPCServerAndClient", () => {
   describe("having a pending request", () => {
     let promise: PromiseLike<void>;
     let resolve: () => void;
+
     beforeEach(() => {
       serverAndClient2.addMethod("hang", () => {
-        return new Promise(givenResolve => (resolve = givenResolve));
+        return new Promise<void>((givenResolve) => (resolve = givenResolve));
       });
 
       promise = serverAndClient1.request("hang");
@@ -92,7 +93,7 @@ describe("JSONRPCServerAndClient", () => {
       it("should reject the pending request", () => {
         return promise.then(
           () => Promise.reject(new Error("Expected to fail")),
-          error => expect(error.message).to.equal(message)
+          (error) => expect(error.message).to.equal(message)
         );
       });
     });

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -4,7 +4,7 @@ import {
   isJSONRPCRequest,
   isJSONRPCResponse,
   JSONRPCParams,
-  JSONRPCResponse
+  JSONRPCResponse,
 } from "./models";
 
 export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
@@ -13,7 +13,7 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     public client: JSONRPCClient<ClientParams>
   ) {}
 
-  addMethod(name: string, method: SimpleJSONRPCMethod): void {
+  addMethod(name: string, method: SimpleJSONRPCMethod<ServerParams>): void {
     this.server.addMethod(name, method);
   }
 

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -32,7 +32,7 @@ describe("JSONRPCServer", () => {
     beforeEach(() => {
       server.addMethod(
         "echo",
-        ({ text }: Params) => (serverParams?: ServerParams) => {
+        ({ text }: Params, serverParams?: ServerParams) => {
           if (serverParams) {
             return `${serverParams.userID} said ${text}`;
           } else {
@@ -49,16 +49,16 @@ describe("JSONRPCServer", () => {
             jsonrpc: JSONRPC,
             id: 0,
             method: "echo",
-            params: { text: "foo" }
+            params: { text: "foo" },
           })
-          .then(givenResponse => (response = givenResponse));
+          .then((givenResponse) => (response = givenResponse));
       });
 
       it("should echo the text", () => {
         expect(response).to.deep.equal({
           jsonrpc: JSONRPC,
           id: 0,
-          result: "foo"
+          result: "foo",
         });
       });
     });
@@ -71,18 +71,18 @@ describe("JSONRPCServer", () => {
               jsonrpc: JSONRPC,
               id: 0,
               method: "echo",
-              params: { text: "foo" }
+              params: { text: "foo" },
             },
             { userID: "bar" }
           )
-          .then(givenResponse => (response = givenResponse));
+          .then((givenResponse) => (response = givenResponse));
       });
 
       it("should echo the text with the user ID", () => {
         expect(response).to.deep.equal({
           jsonrpc: JSONRPC,
           id: 0,
-          result: "bar said foo"
+          result: "bar said foo",
         });
       });
     });
@@ -94,14 +94,14 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "ack" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should response with null result", () => {
       expect(response).to.deep.equal({
         jsonrpc: JSONRPC,
         id: 0,
-        result: null
+        result: null,
       });
     });
   });
@@ -114,7 +114,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "throw" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -123,8 +123,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: 0,
-          message: "Test throwing"
-        }
+          message: "Test throwing",
+        },
       });
     });
   });
@@ -137,7 +137,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, id: 0, method: "reject" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -146,8 +146,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: 0,
-          message: "Test rejecting"
-        }
+          message: "Test rejecting",
+        },
       });
     });
   });
@@ -158,7 +158,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, method: "foo" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should not respond", () => {
@@ -172,7 +172,7 @@ describe("JSONRPCServer", () => {
 
       return server
         .receive({ jsonrpc: JSONRPC, method: "foo" })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should not respond", () => {
@@ -188,9 +188,9 @@ describe("JSONRPCServer", () => {
         .receive({
           jsonrpc: JSONRPC,
           id: 0,
-          method: "foo"
+          method: "foo",
         })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -199,8 +199,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: JSONRPCErrorCode.InternalError,
-          message: "Internal error"
-        }
+          message: "Internal error",
+        },
       });
     });
   });
@@ -211,9 +211,9 @@ describe("JSONRPCServer", () => {
         .receive({
           jsonrpc: JSONRPC,
           id: 0,
-          method: "foo"
+          method: "foo",
         })
-        .then(givenResponse => (response = givenResponse));
+        .then((givenResponse) => (response = givenResponse));
     });
 
     it("should respond error", () => {
@@ -222,8 +222,8 @@ describe("JSONRPCServer", () => {
         id: 0,
         error: {
           code: JSONRPCErrorCode.MethodNotFound,
-          message: "Method not found"
-        }
+          message: "Method not found",
+        },
       });
     });
   });


### PR DESCRIPTION
The JSON-RPC spec allows for error responses to have an opaque data object that the server can stick JSON for a client specific response. This error data would be useful for passing along custom error codes or context about where the error occurred in the remote service if the client and server want to collaborate a bit tighter. This exposes that functionality in the spec to users of the server via a new options object passed to the server constructor. 

The client can then access an error's data via the `error.data` property of the `JSONRPCRemoteError` object that an RPC call rejects with! 

This is on top of #13 and #14 but happy to rebase if need be! 