### PR TITLE
Support batch request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1805,9 +1805,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
+      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "pretty-quick": "^3.1.1",
     "sinon": "^10.0.0",
     "ts-node": "^7.0.1",
-    "typescript": "^3.9.10"
+    "typescript": "^4.5.2"
   }
 }

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -33,11 +33,11 @@ describe("JSONRPCClient", () => {
         resolve = undefined;
         reject = undefined;
 
-        const legacySend = (request: JSONRPCRequest) => (
-          clientParams: ClientParams
-        ): PromiseLike<void> => {
-          return newSend(request, clientParams);
-        };
+        const legacySend =
+          (request: JSONRPCRequest) =>
+          (clientParams: ClientParams): PromiseLike<void> => {
+            return newSend(request, clientParams);
+          };
 
         const newSend = (
           request: JSONRPCRequest,
@@ -265,6 +265,39 @@ describe("JSONRPCClient", () => {
           it("should reject the promise", () => {
             expect(error.message).to.equal("Failed to send a request");
           });
+        });
+      });
+
+      describe("requesting batch", () => {
+        let requests: JSONRPCRequest[];
+        let actualResponses: JSONRPCResponse[];
+        let expectedResponses: JSONRPCResponse[];
+
+        beforeEach(() => {
+          requests = [
+            { jsonrpc: JSONRPC, id: 0, method: "foo" },
+            { jsonrpc: JSONRPC, id: 1, method: "foo2" },
+          ];
+
+          client
+            .requestAdvanced(requests)
+            .then((responses) => (actualResponses = responses));
+
+          resolve!();
+
+          expectedResponses = [
+            { jsonrpc: JSONRPC, id: 0, result: "foo" },
+            { jsonrpc: JSONRPC, id: 1, result: "foo2" },
+          ];
+          client.receive(expectedResponses);
+        });
+
+        it("should send requests in batch", () => {
+          expect(lastRequest).to.deep.equal(requests);
+        });
+
+        it("should return responses", () => {
+          expect(actualResponses).to.deep.equal(expectedResponses);
         });
       });
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -39,12 +39,24 @@ export const isJSONRPCRequest = (payload: any): payload is JSONRPCRequest => {
   );
 };
 
+export const isJSONRPCRequests = (
+  payload: any
+): payload is JSONRPCRequest[] => {
+  return Array.isArray(payload) && payload.every(isJSONRPCRequest);
+};
+
 export const isJSONRPCResponse = (payload: any): payload is JSONRPCResponse => {
   return (
     payload.jsonrpc === JSONRPC &&
     payload.id !== undefined &&
     (payload.result !== undefined || payload.error !== undefined)
   );
+};
+
+export const isJSONRPCResponses = (
+  payload: any
+): payload is JSONRPCResponse[] => {
+  return Array.isArray(payload) && payload.every(isJSONRPCResponse);
 };
 
 export interface JSONRPCError {

--- a/src/server-and-client.spec.ts
+++ b/src/server-and-client.spec.ts
@@ -103,6 +103,26 @@ describe("JSONRPCServerAndClient", () => {
     });
   });
 
+  describe("requesting in batch", () => {
+    let responses: JSONRPCResponse[];
+
+    beforeEach(async () => {
+      const requests: JSONRPCRequest[] = [
+        { jsonrpc: JSONRPC, id: 0, method: "echo2", params: { message: "1" } },
+        { jsonrpc: JSONRPC, id: 1, method: "echo2", params: { message: "2" } },
+      ];
+
+      responses = await serverAndClient1.requestAdvanced(requests);
+    });
+
+    it("should return responses", () => {
+      expect(responses).to.deep.equal([
+        { jsonrpc: JSONRPC, id: 0, result: "1" },
+        { jsonrpc: JSONRPC, id: 1, result: "2" },
+      ]);
+    });
+  });
+
   describe("receiving invalid JSON-RPC message", () => {
     let promise: PromiseLike<void>;
 

--- a/src/server-and-client.spec.ts
+++ b/src/server-and-client.spec.ts
@@ -123,7 +123,7 @@ describe("JSONRPCServerAndClient", () => {
     let resolve: () => void;
     beforeEach(() => {
       serverAndClient2.addMethod("hang", () => {
-        return new Promise((givenResolve) => (resolve = givenResolve));
+        return new Promise<void>((givenResolve) => (resolve = givenResolve));
       });
 
       promise = serverAndClient1.request("hang");
@@ -160,7 +160,7 @@ describe("JSONRPCServerAndClient", () => {
       delay = 100;
       serverAndClient2.addMethod(
         "timeout",
-        () => new Promise((givenResolve) => (resolve = givenResolve))
+        () => new Promise<void>((givenResolve) => (resolve = givenResolve))
       );
 
       promise = serverAndClient1.timeout(delay).request("timeout");

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -7,7 +7,9 @@ import {
 import { JSONRPCClient, JSONRPCRequester } from "./client";
 import {
   isJSONRPCRequest,
+  isJSONRPCRequests,
   isJSONRPCResponse,
+  isJSONRPCResponses,
   JSONRPCParams,
   JSONRPCRequest,
   JSONRPCResponse,
@@ -48,8 +50,16 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest,
     clientParams?: ClientParams
-  ): PromiseLike<JSONRPCResponse> {
-    return this.client.requestAdvanced(jsonRPCRequest, clientParams);
+  ): PromiseLike<JSONRPCResponse>;
+  requestAdvanced(
+    jsonRPCRequest: JSONRPCRequest[],
+    clientParams?: ClientParams
+  ): PromiseLike<JSONRPCResponse[]>;
+  requestAdvanced(
+    jsonRPCRequest: JSONRPCRequest | JSONRPCRequest[],
+    clientParams?: ClientParams
+  ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> {
+    return this.client.requestAdvanced(jsonRPCRequest as any, clientParams);
   }
 
   notify(
@@ -69,13 +79,11 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     serverParams?: ServerParams,
     clientParams?: ClientParams
   ): Promise<void> {
-    if (isJSONRPCResponse(payload)) {
+    if (isJSONRPCResponse(payload) || isJSONRPCResponses(payload)) {
       this.client.receive(payload);
-    } else if (isJSONRPCRequest(payload)) {
-      const response: JSONRPCResponse | null = await this.server.receive(
-        payload,
-        serverParams
-      );
+    } else if (isJSONRPCRequest(payload) || isJSONRPCRequests(payload)) {
+      const response: JSONRPCResponse | JSONRPCResponse[] | null =
+        await this.server.receive(payload, serverParams);
       if (response) {
         return this.client.send(response, clientParams);
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -141,7 +141,7 @@ export class JSONRPCServer<ServerParams = void> {
     serverParams?: ServerParams
   ): PromiseLike<JSONRPCResponse | null>;
   receive(
-    request: JSONRPCRequest[],
+    request: JSONRPCRequest | JSONRPCRequest[],
     serverParams?: ServerParams
   ): PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null>;
   receive(

--- a/src/server.ts
+++ b/src/server.ts
@@ -118,8 +118,9 @@ export class JSONRPCServer<ServerParams = void> {
   receiveJSON(
     json: string,
     serverParams?: ServerParams
-  ): JSONRPCResponsePromise {
-    const request: JSONRPCRequest | null = this.tryParseRequestJSON(json);
+  ): PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null> {
+    const request: JSONRPCRequest | JSONRPCRequest[] | null =
+      this.tryParseRequestJSON(json);
     if (request) {
       return this.receive(request, serverParams);
     } else {
@@ -136,6 +137,50 @@ export class JSONRPCServer<ServerParams = void> {
   }
 
   receive(
+    request: JSONRPCRequest,
+    serverParams?: ServerParams
+  ): PromiseLike<JSONRPCResponse | null>;
+  receive(
+    request: JSONRPCRequest[],
+    serverParams?: ServerParams
+  ): PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null>;
+  receive(
+    request: JSONRPCRequest | JSONRPCRequest[],
+    serverParams?: ServerParams
+  ): PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null> {
+    if (Array.isArray(request)) {
+      return this.receiveMultiple(request, serverParams);
+    } else {
+      return this.receiveSingle(request, serverParams);
+    }
+  }
+
+  private receiveMultiple(
+    requests: JSONRPCRequest[],
+    serverParams?: ServerParams
+  ): PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null> {
+    return Promise.all(
+      requests.map((request) => this.receiveSingle(request, serverParams))
+    )
+      .then((responses: (JSONRPCResponse | null)[]): JSONRPCResponse[] =>
+        responses.filter(isNonNull)
+      )
+      .then(
+        (
+          responses: JSONRPCResponse[]
+        ): JSONRPCResponse[] | JSONRPCResponse | null => {
+          if (responses.length === 1) {
+            return responses[0];
+          } else if (responses.length) {
+            return responses;
+          } else {
+            return null;
+          }
+        }
+      );
+  }
+
+  private receiveSingle(
     request: JSONRPCRequest,
     serverParams?: ServerParams
   ): JSONRPCResponsePromise {
@@ -247,6 +292,8 @@ export class JSONRPCServer<ServerParams = void> {
     }
   }
 }
+
+const isNonNull = <T>(value: T | null): value is T => value !== null;
 
 const noopMiddleware: JSONRPCServerMiddleware<any> = (
   next,


### PR DESCRIPTION
Close #25

I will release this as part of v1.0.0 because it introduces a breaking change (`client.receiveJSON`'s return type is changed from `PromiseLike<JSONRPCResponse | null>` to `PromiseLike<JSONRPCResponse | JSONRPCResponse[] | null>`).

Since it introduces a breaking change anyway, I will tidy up some before releasing. E.g., removing legacy APIs, using async/await.