### PR TITLE
Add setDefaultMethod to server to give the ability to catch unknown messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ new JSONRPCServer({
 });
 ```
 
+#### Default Method
+
+Use the default method to catch methods that are not explicitly added. Unlike addMethod it provides the raw request as the first argument.
+
+```javascript
+const server = new JSONRPCServer();
+
+server.setDefaultMethod(({ method, params }) =>
+  Promise.reject(new Error(`method with name '${method}' was not found`))
+);
+```
+
 ### Client
 
 ```javascript

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -41,8 +41,16 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     this.server.addMethod(name, method);
   }
 
+  setDefaultMethod(method: SimpleJSONRPCMethod<ServerParams>): void {
+    this.server.setDefaultMethod(method);
+  }
+
   addMethodAdvanced(name: string, method: JSONRPCMethod<ServerParams>): void {
     this.server.addMethodAdvanced(name, method);
+  }
+
+  setDefaultMethodAdvanced(method: JSONRPCMethod<ServerParams>): void {
+    this.server.setDefaultMethodAdvanced(method);
   }
 
   timeout(delay: number): JSONRPCRequester<ClientParams> {

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -213,7 +213,7 @@ describe("JSONRPCServer", () => {
     });
   });
 
-  describe("receiving a request to an unknown method", () => {
+  describe("receiving a request to an unknown method without default set", () => {
     beforeEach(() => {
       return server
         .receive({
@@ -232,6 +232,28 @@ describe("JSONRPCServer", () => {
           code: JSONRPCErrorCode.MethodNotFound,
           message: "Method not found",
         },
+      });
+    });
+  });
+
+  describe("receiving a request to an unknown method with default set", () => {
+    beforeEach(() => {
+      server.setDefaultMethod(() => Promise.resolve(null));
+
+      return server
+        .receive({
+          jsonrpc: JSONRPC,
+          id: 0,
+          method: "foo",
+        })
+        .then((givenResponse) => (response = givenResponse));
+    });
+
+    it("should respond null to a request", () => {
+      expect(response).to.deep.equal({
+        jsonrpc: JSONRPC,
+        id: 0,
+        result: null,
       });
     });
   });

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -236,7 +236,7 @@ describe("JSONRPCServer", () => {
     });
   });
 
-  describe("receiving a request to an unknown method with default set", () => {
+  describe("receiving a request to an unknown method with a default method that responds null", () => {
     beforeEach(() => {
       server.setDefaultMethod(() => Promise.resolve(null));
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,7 +92,10 @@ export class JSONRPCServer<ServerParams = void> {
       serverParams: ServerParams
     ): JSONRPCResponsePromise => {
       const hasMethod = !!this.nameToMethodDictionary[request.method];
-      const response = method(hasMethod ? request.params : request, serverParams);
+      const response = method(
+        hasMethod ? request.params : request,
+        serverParams
+      );
 
       return Promise.resolve(response).then((result: any) =>
         mapResultToJSONRPCResponse(request.id, result)
@@ -174,20 +177,14 @@ export class JSONRPCServer<ServerParams = void> {
     request: JSONRPCRequest,
     serverParams?: ServerParams
   ): Promise<JSONRPCResponse | null> {
-    const method = this.nameToMethodDictionary[request.method] ?? this.defaultMethod;
+    const method =
+      this.nameToMethodDictionary[request.method] ?? this.defaultMethod;
 
     if (!isJSONRPCRequest(request)) {
       return createInvalidRequestResponse(request);
     } else if (method) {
       const response: JSONRPCResponse | null = await this.callMethod(
         method,
-        request,
-        serverParams
-      );
-      return mapResponse(request, response);
-    } else if (request.id !== undefined && defaultMethod) {
-      const response: JSONRPCResponse | null = await this.callMethod(
-        defaultMethod,
         request,
         serverParams
       );

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,8 +174,7 @@ export class JSONRPCServer<ServerParams = void> {
     request: JSONRPCRequest,
     serverParams?: ServerParams
   ): Promise<JSONRPCResponse | null> {
-    const method = this.nameToMethodDictionary[request.method];
-    const defaultMethod = this.defaultMethod;
+    const method = this.nameToMethodDictionary[request.method] ?? this.defaultMethod;
 
     if (!isJSONRPCRequest(request)) {
       return createInvalidRequestResponse(request);


### PR DESCRIPTION
This adds the ability to catch all messages that are not specifically handled by `addMethod`. To use this functionality just call the `setDefaultMethod` method on the JSONRPCServer instance. This is useful for messages that are unknown until runtime.

Usage example:
```javascript
server.setDefaultMethod(({ method, params }) =>
	Promise.reject(
		`unknown method called: ${method}(${JSON.stringify(params)})`
	)
);
```