### PR TITLE
Fix "Method not found" errors bypassing middleware.

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -221,16 +221,16 @@ export class JSONRPCServer<ServerParams = void> {
     request: JSONRPCRequest,
     serverParams: ServerParams | undefined
   ): JSONRPCResponsePromise {
-    const callMethod: JSONRPCServerMiddlewareNext<ServerParams> = async (
+    const callMethod: JSONRPCServerMiddlewareNext<ServerParams> = (
       request: JSONRPCRequest,
       serverParams: ServerParams | undefined
     ): JSONRPCResponsePromise => {
       if (method) {
         return method(request, serverParams);
       } else if (request.id !== undefined) {
-        return createMethodNotFoundResponse(request.id);
+        return Promise.resolve(createMethodNotFoundResponse(request.id));
       } else {
-        return null;
+        return Promise.resolve(null);
       }
     };
 


### PR DESCRIPTION
Made changes suggested in #33 to make it possible to catch "Method not found" (-32601) errors in middleware.
 