### PR TITLE
Add functions for creating request and response objects.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import {
   createJSONRPCErrorResponse,
+  createJSONRPCRequest,
   JSONRPC,
   JSONRPCErrorResponse,
   JSONRPCID,
@@ -134,12 +135,7 @@ export class JSONRPCClient<ClientParams = void>
     clientParams: ClientParams | undefined,
     id: JSONRPCID
   ): Promise<any> {
-    const request: JSONRPCRequest = {
-      jsonrpc: JSONRPC,
-      method,
-      params,
-      id,
-    };
+    const request: JSONRPCRequest = createJSONRPCRequest(method, params, id);
 
     const response: JSONRPCResponse = await this.requestAdvanced(
       request,
@@ -214,14 +210,9 @@ export class JSONRPCClient<ClientParams = void>
     params?: JSONRPCParams,
     clientParams?: ClientParams
   ): void {
-    this.send(
-      {
-        jsonrpc: JSONRPC,
-        method,
-        params,
-      },
-      clientParams
-    ).then(undefined, () => undefined);
+    const request: JSONRPCRequest = createJSONRPCRequest(method, params);
+
+    this.send(request, clientParams).then(undefined, () => undefined);
   }
 
   send(

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,7 @@
 import {
   createJSONRPCErrorResponse,
   createJSONRPCRequest,
+  createJSONRPCNotification,
   JSONRPC,
   JSONRPCErrorResponse,
   JSONRPCID,
@@ -135,7 +136,7 @@ export class JSONRPCClient<ClientParams = void>
     clientParams: ClientParams | undefined,
     id: JSONRPCID
   ): Promise<any> {
-    const request: JSONRPCRequest = createJSONRPCRequest(method, params, id);
+    const request: JSONRPCRequest = createJSONRPCRequest(id, method, params);
 
     const response: JSONRPCResponse = await this.requestAdvanced(
       request,
@@ -210,7 +211,7 @@ export class JSONRPCClient<ClientParams = void>
     params?: JSONRPCParams,
     clientParams?: ClientParams
   ): void {
-    const request: JSONRPCRequest = createJSONRPCRequest(method, params);
+    const request: JSONRPCRequest = createJSONRPCNotification(method, params);
 
     this.send(request, clientParams).then(undefined, () => undefined);
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -103,4 +103,20 @@ export const createJSONRPCSuccessResponse = (
   };
 };
 
+export const createJSONRPCRequest = (
+  method: string,
+  params?: JSONRPCParams,
+  id?: JSONRPCID
+): JSONRPCRequest => {
+  const response: JSONRPCRequest = {
+    jsonrpc: JSONRPC,
+    method,
+    params,
+  };
+
+  if (id !== undefined) response.id = id;
+
+  return response;
+};
+
 export type ErrorListener = (message: string, data: unknown) => void;

--- a/src/models.ts
+++ b/src/models.ts
@@ -92,4 +92,15 @@ export const createJSONRPCErrorResponse = (
   };
 };
 
+export const createJSONRPCSuccessResponse = (
+  id: JSONRPCID,
+  result?: any
+): JSONRPCSuccessResponse => {
+  return {
+    jsonrpc: JSONRPC,
+    id,
+    result: result ?? null,
+  };
+};
+
 export type ErrorListener = (message: string, data: unknown) => void;

--- a/src/models.ts
+++ b/src/models.ts
@@ -104,19 +104,27 @@ export const createJSONRPCSuccessResponse = (
 };
 
 export const createJSONRPCRequest = (
+  id: JSONRPCID,
   method: string,
-  params?: JSONRPCParams,
-  id?: JSONRPCID
+  params?: JSONRPCParams
 ): JSONRPCRequest => {
-  const response: JSONRPCRequest = {
+  return {
+    jsonrpc: JSONRPC,
+    id,
+    method,
+    params,
+  };
+};
+
+export const createJSONRPCNotification = (
+  method: string,
+  params?: JSONRPCParams
+): JSONRPCRequest => {
+  return {
     jsonrpc: JSONRPC,
     method,
     params,
   };
-
-  if (id !== undefined) response.id = id;
-
-  return response;
 };
 
 export type ErrorListener = (message: string, data: unknown) => void;

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,9 +6,11 @@ import {
   JSONRPCID,
   JSONRPCErrorCode,
   createJSONRPCErrorResponse,
+  createJSONRPCSuccessResponse,
   isJSONRPCRequest,
   isJSONRPCID,
   JSONRPCErrorResponse,
+  JSONRPCSuccessResponse,
   ErrorListener,
 } from "./models";
 import { DefaultErrorCode } from "./internal";
@@ -278,13 +280,9 @@ const noopMiddleware: JSONRPCServerMiddleware<any> = (
 const mapResultToJSONRPCResponse = (
   id: JSONRPCID | undefined,
   result: any
-): JSONRPCResponse | null => {
+): JSONRPCSuccessResponse | null => {
   if (id !== undefined) {
-    return {
-      jsonrpc: JSONRPC,
-      id,
-      result: result === undefined ? null : result,
-    };
+    return createJSONRPCSuccessResponse(id, result);
   } else {
     return null;
   }


### PR DESCRIPTION
This PR implements functions for `createJSONRPCSuccessResponse` and `createJSONRPCRequest` similar to `createJSONRPCSuccessResponse`.

The reason for the `createJSONRPCSuccessResponse` function is the need to create custom responses in middleware or the advanced API and the responsibility for the format for these responses should not rest only on the user - the library should provide the tools to do this.

The reason for the `createJSONRPCRequest` function is for when the user wants to make requests to the server directly instead of through a client. Although this is not a very strong reason for the existence of this one, I think for the sake of completeness it should still be included.