### PR TITLE
Add hasMethod.

### DIFF
--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -37,6 +37,10 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     this.server.applyMiddleware(...middlewares);
   }
 
+  hasMethod(name: string): boolean {
+    return this.server.hasMethod(name);
+  }
+
   addMethod(name: string, method: SimpleJSONRPCMethod<ServerParams>): void {
     this.server.addMethod(name, method);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,10 @@ export class JSONRPCServer<ServerParams = void> {
     this.errorListener = options.errorListener ?? console.warn;
   }
 
+  hasMethod(name: string): boolean {
+    return !!this.nameToMethodDictionary[name];
+  }
+
   addMethod(name: string, method: SimpleJSONRPCMethod<ServerParams>): void {
     this.addMethodAdvanced(name, this.toJSONRPCMethod(method));
   }


### PR DESCRIPTION
This is a small change to the server classes that implements `hasMethod` which will tell you if a method is set or not.

The reason for this addition is for checking if a notification is already being handled from within middleware. With requests we can check if the response is a "Method not found" response but since notifications just return null we can't know if it has already been handled by `addMethod`.

If there is a more preferable way to solve this problem let me know and I will look at doing another PR.