### PR TITLE
Reject failed requests with JSON-RPC error objects.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,8 @@ import {
   createJSONRPCRequest,
   createJSONRPCNotification,
   JSONRPC,
+  JSONRPCError,
+  JSONRPCErrorCode,
   JSONRPCErrorResponse,
   JSONRPCID,
   JSONRPCParams,
@@ -145,9 +147,14 @@ export class JSONRPCClient<ClientParams = void>
     if (response.result !== undefined && !response.error) {
       return response.result;
     } else if (response.result === undefined && response.error) {
-      return Promise.reject(new Error(response.error.message));
+      return Promise.reject(response.error);
     } else {
-      return Promise.reject(new Error("An unexpected error occurred"));
+      const error: JSONRPCError = {
+        code: JSONRPCErrorCode.ParseError,
+        message: "Received an invalid request",
+      };
+
+      return Promise.reject(error);
     }
   }
 


### PR DESCRIPTION
As it currently is, the error that is rejected by a failed "request" call is of type "Error" which contains only the "message" property of the RPC error, this means the "code" and "data" properties are lost. This PR changes the type of objects that are thrown by the client when it receives an error response. This is useful for a couple of reasons:
* Handle different errors differently according to the error code.
* Access the "data" property of the error.

The only other way I can find to access these properties is using the "requestAdvanced" method but it requires you to create a JSONRPCRequest which adds unnecessary complication. This PR improves the solution to issue #7.