### PR TITLE
Expose JSON-RPC error parameters via JSONRPCError class.

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -9,6 +9,7 @@ import {
   JSONRPCID,
   JSONRPCErrorResponse,
   createJSONRPCErrorResponse,
+  JSONRPCError,
   JSONRPCErrorObject,
 } from ".";
 
@@ -125,6 +126,7 @@ describe("JSONRPCClient", () => {
             error: {
               code: 0,
               message: "This is a test. Do not panic.",
+              data: { optional: "data" },
             },
           };
 
@@ -133,8 +135,16 @@ describe("JSONRPCClient", () => {
           return promise;
         });
 
-        it("should reject with the error message", () => {
+        it("should reject with the error message, code and data", () => {
           expect(error.message).to.equal(response.error!.message);
+          expect(error.code).to.equal(response.error!.code);
+          expect(error.data).to.equal(response.error!.data);
+        });
+
+        it("should reject with a JSONRPCError", () => {
+          expect(error instanceof Error).to.be.true;
+          expect(error instanceof JSONRPCError).to.be.true;
+          expect(error.toObject()).to.deep.equal(response.error);
         });
       });
 

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -9,7 +9,7 @@ import {
   JSONRPCID,
   JSONRPCErrorResponse,
   createJSONRPCErrorResponse,
-  JSONRPCError,
+  JSONRPCErrorObject,
 } from ".";
 
 interface ClientParams {
@@ -438,7 +438,7 @@ describe("JSONRPCClient", () => {
 
       it("should reject with the custom error", async () => {
         const actual: JSONRPCResponse = await promise;
-        const expected: JSONRPCError = {
+        const expected: JSONRPCErrorObject = {
           code: errorCode,
           message: errorMessage,
           data: errorData,

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -9,8 +9,8 @@ import {
   JSONRPCID,
   JSONRPCErrorResponse,
   createJSONRPCErrorResponse,
+  JSONRPCErrorException,
   JSONRPCError,
-  JSONRPCErrorObject,
 } from ".";
 
 interface ClientParams {
@@ -141,9 +141,9 @@ describe("JSONRPCClient", () => {
           expect(error.data).to.equal(response.error!.data);
         });
 
-        it("should reject with a JSONRPCError", () => {
+        it("should reject with a JSONRPCErrorException", () => {
           expect(error instanceof Error).to.be.true;
-          expect(error instanceof JSONRPCError).to.be.true;
+          expect(error instanceof JSONRPCErrorException).to.be.true;
           expect(error.toObject()).to.deep.equal(response.error);
         });
       });
@@ -448,7 +448,7 @@ describe("JSONRPCClient", () => {
 
       it("should reject with the custom error", async () => {
         const actual: JSONRPCResponse = await promise;
-        const expected: JSONRPCErrorObject = {
+        const expected: JSONRPCError = {
           code: errorCode,
           message: errorMessage,
           data: errorData,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import {
   createJSONRPCRequest,
   createJSONRPCNotification,
   JSONRPC,
-  JSONRPCError,
+  JSONRPCErrorException,
   JSONRPCErrorCode,
   JSONRPCErrorResponse,
   JSONRPCID,
@@ -148,7 +148,7 @@ export class JSONRPCClient<ClientParams = void>
       return response.result;
     } else if (response.result === undefined && response.error) {
       return Promise.reject(
-        new JSONRPCError(
+        new JSONRPCErrorException(
           response.error.code,
           response.error.message,
           response.error.data
@@ -156,7 +156,7 @@ export class JSONRPCClient<ClientParams = void>
       );
     } else {
       return Promise.reject(
-        new JSONRPCError(
+        new JSONRPCErrorException(
           JSONRPCErrorCode.ParseError,
           "Received an invalid request"
         )

--- a/src/client.ts
+++ b/src/client.ts
@@ -149,16 +149,16 @@ export class JSONRPCClient<ClientParams = void>
     } else if (response.result === undefined && response.error) {
       return Promise.reject(
         new JSONRPCErrorException(
-          response.error.code,
           response.error.message,
+          response.error.code,
           response.error.data
         )
       );
     } else {
       return Promise.reject(
         new JSONRPCErrorException(
-          DefaultErrorCode,
-          "An unexpected error occurred"
+          "An unexpected error occurred",
+          DefaultErrorCode
         )
       );
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -155,12 +155,7 @@ export class JSONRPCClient<ClientParams = void>
         )
       );
     } else {
-      return Promise.reject(
-        new JSONRPCErrorException(
-          "An unexpected error occurred",
-          DefaultErrorCode
-        )
-      );
+      return Promise.reject(new Error("An unexpected error occurred"));
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,6 +3,8 @@ import {
   createJSONRPCRequest,
   createJSONRPCNotification,
   JSONRPC,
+  JSONRPCError,
+  JSONRPCErrorCode,
   JSONRPCErrorResponse,
   JSONRPCID,
   JSONRPCParams,
@@ -145,9 +147,20 @@ export class JSONRPCClient<ClientParams = void>
     if (response.result !== undefined && !response.error) {
       return response.result;
     } else if (response.result === undefined && response.error) {
-      return Promise.reject(new Error(response.error.message));
+      return Promise.reject(
+        new JSONRPCError(
+          response.error.code,
+          response.error.message,
+          response.error.data
+        )
+      );
     } else {
-      return Promise.reject(new Error("An unexpected error occurred"));
+      return Promise.reject(
+        new JSONRPCError(
+          JSONRPCErrorCode.ParseError,
+          "Received an invalid request"
+        )
+      );
     }
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -157,8 +157,8 @@ export class JSONRPCClient<ClientParams = void>
     } else {
       return Promise.reject(
         new JSONRPCErrorException(
-          JSONRPCErrorCode.ParseError,
-          "Received an invalid request"
+          DefaultErrorCode,
+          "An unexpected error occurred"
         )
       );
     }

--- a/src/models.ts
+++ b/src/models.ts
@@ -72,6 +72,10 @@ export class JSONRPCError extends Error implements JSONRPCErrorObject {
   constructor(code: number, message: string, data?: any) {
     super(message);
 
+    // Manually set the prototype to fix TypeScript issue:
+    // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+    Object.setPrototypeOf(this, JSONRPCError.prototype);
+
     this.code = code;
     this.data = data;
   }

--- a/src/models.ts
+++ b/src/models.ts
@@ -27,7 +27,7 @@ export interface JSONRPCErrorResponse {
   jsonrpc: JSONRPC;
   id: JSONRPCID;
   result?: undefined;
-  error: JSONRPCError;
+  error: JSONRPCErrorObject;
 }
 
 export const isJSONRPCRequest = (payload: any): payload is JSONRPCRequest => {
@@ -59,7 +59,7 @@ export const isJSONRPCResponses = (
   return Array.isArray(payload) && payload.every(isJSONRPCResponse);
 };
 
-export interface JSONRPCError {
+export interface JSONRPCErrorObject {
   code: number;
   message: string;
   data?: any;
@@ -79,7 +79,7 @@ export const createJSONRPCErrorResponse = (
   message: string,
   data?: any
 ): JSONRPCErrorResponse => {
-  const error: JSONRPCError = { code, message };
+  const error: JSONRPCErrorObject = { code, message };
 
   if (data) {
     error.data = data;

--- a/src/models.ts
+++ b/src/models.ts
@@ -65,6 +65,20 @@ export interface JSONRPCError {
   data?: any;
 }
 
+const createJSONRPCError = (
+  code: number,
+  message: string,
+  data?: any
+): JSONRPCError => {
+  const error: JSONRPCError = { code, message };
+
+  if (data != null) {
+    error.data = data;
+  }
+
+  return error;
+};
+
 export class JSONRPCErrorException extends Error implements JSONRPCError {
   public code: number;
   public data?: any;
@@ -81,16 +95,7 @@ export class JSONRPCErrorException extends Error implements JSONRPCError {
   }
 
   toObject(): JSONRPCError {
-    const obj: JSONRPCError = {
-      code: this.code,
-      message: this.message,
-    };
-
-    if (this.data) {
-      obj.data = this.data;
-    }
-
-    return obj;
+    return createJSONRPCError(this.code, this.message, this.data);
   }
 }
 
@@ -108,16 +113,10 @@ export const createJSONRPCErrorResponse = (
   message: string,
   data?: any
 ): JSONRPCErrorResponse => {
-  const error: JSONRPCErrorException = new JSONRPCErrorException(
-    code,
-    message,
-    data
-  );
-
   return {
     jsonrpc: JSONRPC,
     id,
-    error: error.toObject(),
+    error: createJSONRPCError(code, message, data),
   };
 };
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -108,16 +108,12 @@ export const createJSONRPCErrorResponse = (
   message: string,
   data?: any
 ): JSONRPCErrorResponse => {
-  const error: JSONRPCErrorObject = { code, message };
-
-  if (data) {
-    error.data = data;
-  }
+  const error: JSONRPCError = new JSONRPCError(code, message, data);
 
   return {
     jsonrpc: JSONRPC,
     id,
-    error,
+    error: error.toObject(),
   };
 };
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -83,7 +83,7 @@ export class JSONRPCErrorException extends Error implements JSONRPCError {
   public code: number;
   public data?: any;
 
-  constructor(code: number, message: string, data?: any) {
+  constructor(message: string, code: number, data?: any) {
     super(message);
 
     // Manually set the prototype to fix TypeScript issue:

--- a/src/models.ts
+++ b/src/models.ts
@@ -65,6 +65,31 @@ export interface JSONRPCErrorObject {
   data?: any;
 }
 
+export class JSONRPCError extends Error implements JSONRPCErrorObject {
+  public code: number;
+  public data?: any;
+
+  constructor(code: number, message: string, data?: any) {
+    super(message);
+
+    this.code = code;
+    this.data = data;
+  }
+
+  toObject(): JSONRPCErrorObject {
+    const obj: JSONRPCErrorObject = {
+      code: this.code,
+      message: this.message,
+    };
+
+    if (this.data) {
+      obj.data = this.data;
+    }
+
+    return obj;
+  }
+}
+
 export enum JSONRPCErrorCode {
   ParseError = -32700,
   InvalidRequest = -32600,

--- a/src/models.ts
+++ b/src/models.ts
@@ -27,7 +27,7 @@ export interface JSONRPCErrorResponse {
   jsonrpc: JSONRPC;
   id: JSONRPCID;
   result?: undefined;
-  error: JSONRPCErrorObject;
+  error: JSONRPCError;
 }
 
 export const isJSONRPCRequest = (payload: any): payload is JSONRPCRequest => {
@@ -59,13 +59,13 @@ export const isJSONRPCResponses = (
   return Array.isArray(payload) && payload.every(isJSONRPCResponse);
 };
 
-export interface JSONRPCErrorObject {
+export interface JSONRPCError {
   code: number;
   message: string;
   data?: any;
 }
 
-export class JSONRPCError extends Error implements JSONRPCErrorObject {
+export class JSONRPCErrorException extends Error implements JSONRPCError {
   public code: number;
   public data?: any;
 
@@ -74,14 +74,14 @@ export class JSONRPCError extends Error implements JSONRPCErrorObject {
 
     // Manually set the prototype to fix TypeScript issue:
     // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
-    Object.setPrototypeOf(this, JSONRPCError.prototype);
+    Object.setPrototypeOf(this, JSONRPCErrorException.prototype);
 
     this.code = code;
     this.data = data;
   }
 
-  toObject(): JSONRPCErrorObject {
-    const obj: JSONRPCErrorObject = {
+  toObject(): JSONRPCError {
+    const obj: JSONRPCError = {
       code: this.code,
       message: this.message,
     };
@@ -108,7 +108,11 @@ export const createJSONRPCErrorResponse = (
   message: string,
   data?: any
 ): JSONRPCErrorResponse => {
-  const error: JSONRPCError = new JSONRPCError(code, message, data);
+  const error: JSONRPCErrorException = new JSONRPCErrorException(
+    code,
+    message,
+    data
+  );
 
   return {
     jsonrpc: JSONRPC,

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import {
   JSONRPC,
   JSONRPCID,
   JSONRPCErrorCode,
+  JSONRPCErrorException,
   createJSONRPCErrorResponse,
   createJSONRPCSuccessResponse,
   isJSONRPCRequest,
@@ -296,12 +297,20 @@ const defaultMapErrorToJSONRPCErrorResponse = (
   id: JSONRPCID,
   error: any
 ): JSONRPCErrorResponse => {
-  return createJSONRPCErrorResponse(
-    id,
-    error?.code || DefaultErrorCode,
-    error?.message || "An unexpected error occurred",
-    error?.data
-  );
+  let message: string = "An unexpected error occurred";
+  let code: number = DefaultErrorCode;
+  let data: any;
+
+  if (error instanceof Error) {
+    message = error.message;
+  }
+
+  if (error instanceof JSONRPCErrorException) {
+    code = error.code;
+    data = error.data;
+  }
+
+  return createJSONRPCErrorResponse(id, code, message, data);
 };
 
 const mapResponse = (

--- a/src/server.ts
+++ b/src/server.ts
@@ -298,8 +298,9 @@ const defaultMapErrorToJSONRPCErrorResponse = (
 ): JSONRPCErrorResponse => {
   return createJSONRPCErrorResponse(
     id,
-    DefaultErrorCode,
-    (error && error.message) || "An unexpected error occurred"
+    error?.code || DefaultErrorCode,
+    error?.message || "An unexpected error occurred",
+    error?.data
   );
 };
 


### PR DESCRIPTION
This PR adds the `JSONRPCError` class which adds the `code` and `data` parameters to the `Error` object that is thrown by failed client requests. This was created to address the concerns raised in PR #38.