### PR TITLE
Make it strict mode compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1068,9 +1068,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1835,9 +1835,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "pretty-quick": "^3.1.3",
     "sinon": "^10.0.0",
     "ts-node": "^7.0.1",
-    "typescript": "^4.6.3"
+    "typescript": "^4.9.3"
   }
 }

--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -60,7 +60,7 @@ describe("JSONRPCClient", () => {
       result = undefined;
       error = undefined;
 
-      promise = client.request("foo", ["bar"]).then(
+      promise = client.request("foo", ["bar"], { token: "" }).then(
         (givenResult) => (result = givenResult),
         (givenError) => (error = givenError)
       );
@@ -279,7 +279,7 @@ describe("JSONRPCClient", () => {
       ];
 
       client
-        .requestAdvanced(requests)
+        .requestAdvanced(requests, { token: "" })
         .then((responses) => (actualResponses = responses));
 
       resolve!();
@@ -460,7 +460,7 @@ describe("JSONRPCClient", () => {
 
   describe("notifying", () => {
     beforeEach(() => {
-      client.notify("foo", ["bar"]);
+      client.notify("foo", ["bar"], { token: "" });
     });
 
     it("should send the notification", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import { DefaultErrorCode } from "./internal";
 
 export type SendRequest<ClientParams> = (
   payload: any,
-  clientParams: ClientParams | undefined
+  clientParams: ClientParams
 ) => PromiseLike<void>;
 export type CreateID = () => JSONRPCID;
 
@@ -94,7 +94,7 @@ export class JSONRPCClient<ClientParams = void>
 
     const requestAdvanced = (
       request: JSONRPCRequest | JSONRPCRequest[],
-      clientParams?: ClientParams
+      clientParams: ClientParams
     ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> => {
       const ids: JSONRPCID[] = (!Array.isArray(request) ? [request] : request)
         .map((request) => request.id)
@@ -107,8 +107,8 @@ export class JSONRPCClient<ClientParams = void>
     return {
       request: (
         method: string,
-        params?: JSONRPCParams,
-        clientParams?: ClientParams
+        params: JSONRPCParams,
+        clientParams: ClientParams
       ): PromiseLike<any> => {
         const id: JSONRPCID = this._createID();
         return timeoutRequest([id], () =>
@@ -117,15 +117,15 @@ export class JSONRPCClient<ClientParams = void>
       },
       requestAdvanced: (
         request: any,
-        clientParams?: ClientParams
+        clientParams: ClientParams
       ): PromiseLike<any> => requestAdvanced(request, clientParams),
     };
   }
 
   request(
     method: string,
-    params?: JSONRPCParams,
-    clientParams?: ClientParams
+    params: JSONRPCParams,
+    clientParams: ClientParams
   ): PromiseLike<any> {
     return this.requestWithID(method, params, clientParams, this._createID());
   }
@@ -133,7 +133,7 @@ export class JSONRPCClient<ClientParams = void>
   private async requestWithID(
     method: string,
     params: JSONRPCParams | undefined,
-    clientParams: ClientParams | undefined,
+    clientParams: ClientParams,
     id: JSONRPCID
   ): Promise<any> {
     const request: JSONRPCRequest = createJSONRPCRequest(id, method, params);
@@ -159,15 +159,15 @@ export class JSONRPCClient<ClientParams = void>
 
   requestAdvanced(
     request: JSONRPCRequest,
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse>;
   requestAdvanced(
     request: JSONRPCRequest[],
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse[]>;
   requestAdvanced(
     requests: JSONRPCRequest | JSONRPCRequest[],
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> {
     const areRequestsOriginallyArray = Array.isArray(requests);
     if (!Array.isArray(requests)) {
@@ -214,18 +214,15 @@ export class JSONRPCClient<ClientParams = void>
 
   notify(
     method: string,
-    params?: JSONRPCParams,
-    clientParams?: ClientParams
+    params: JSONRPCParams,
+    clientParams: ClientParams
   ): void {
     const request: JSONRPCRequest = createJSONRPCNotification(method, params);
 
     this.send(request, clientParams).then(undefined, () => undefined);
   }
 
-  send(
-    payload: any,
-    clientParams: ClientParams | undefined
-  ): PromiseLike<void> {
+  send(payload: any, clientParams: ClientParams): PromiseLike<void> {
     return this._send(payload, clientParams);
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,9 +2,7 @@ import {
   createJSONRPCErrorResponse,
   createJSONRPCRequest,
   createJSONRPCNotification,
-  JSONRPC,
   JSONRPCErrorException,
-  JSONRPCErrorCode,
   JSONRPCErrorResponse,
   JSONRPCID,
   JSONRPCParams,
@@ -232,7 +230,7 @@ export class JSONRPCClient<ClientParams = void>
   }
 
   rejectAllPendingRequests(message: string): void {
-    this.idToResolveMap.forEach((resolve: Resolve, id: string) =>
+    this.idToResolveMap.forEach((resolve: Resolve, id: JSONRPCID) =>
       resolve(createJSONRPCErrorResponse(id, DefaultErrorCode, message))
     );
     this.idToResolveMap.clear();

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -13,8 +13,8 @@ describe("JSONRPCClient and JSONRPCServer", () => {
 
     server = new JSONRPCServer();
     client = new JSONRPCClient(
-      request => {
-        return server.receive(request).then(response => {
+      (request) => {
+        return server.receive(request).then((response) => {
           if (response) {
             client.receive(response);
           }
@@ -29,8 +29,8 @@ describe("JSONRPCClient and JSONRPCServer", () => {
       server.addMethod("foo", () => "bar");
 
       return client
-        .request("foo")
-        .then(result => expect(result).to.equal("bar"));
+        .request("foo", undefined)
+        .then((result) => expect(result).to.equal("bar"));
     });
   });
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,7 +2,7 @@ export type JSONRPC = "2.0";
 export const JSONRPC: JSONRPC = "2.0";
 
 export type JSONRPCID = string | number | null;
-export type JSONRPCParams = object | any[];
+export type JSONRPCParams = any;
 
 export const isJSONRPCID = (id: any): id is JSONRPCID =>
   typeof id === "string" || typeof id === "number" || id === null;

--- a/src/server-and-client.spec.ts
+++ b/src/server-and-client.spec.ts
@@ -19,21 +19,21 @@ interface ServerParams {
 }
 
 describe("JSONRPCServerAndClient", () => {
-  let serverAndClient1: JSONRPCServerAndClient<ServerParams>;
-  let serverAndClient2: JSONRPCServerAndClient<void, ServerParams>;
+  let serverAndClient1: JSONRPCServerAndClient<ServerParams | void>;
+  let serverAndClient2: JSONRPCServerAndClient<void, ServerParams | void>;
 
   beforeEach(() => {
     serverAndClient1 = new JSONRPCServerAndClient(
-      new JSONRPCServer<ServerParams>(),
+      new JSONRPCServer<ServerParams | void>(),
       new JSONRPCClient((payload: object) => {
-        return serverAndClient2.receiveAndSend(payload);
+        return serverAndClient2.receiveAndSend(payload, undefined);
       })
     );
 
-    serverAndClient2 = new JSONRPCServerAndClient<void, ServerParams>(
+    serverAndClient2 = new JSONRPCServerAndClient(
       new JSONRPCServer(),
-      new JSONRPCClient<ServerParams>(
-        (payload: object, params: ServerParams) => {
+      new JSONRPCClient<ServerParams | void>(
+        (payload: object, params: ServerParams | void) => {
           return serverAndClient1.receiveAndSend(payload, params);
         }
       )
@@ -44,11 +44,11 @@ describe("JSONRPCServerAndClient", () => {
       "echo1-2",
       async (
         jsonRPCRequest: JSONRPCRequest,
-        { userID }: ServerParams
+        params: ServerParams | void
       ): Promise<JSONRPCResponse> => ({
         jsonrpc: JSONRPC,
         id: jsonRPCRequest.id!,
-        result: `${userID} said ${
+        result: `${params?.userID} said ${
           (jsonRPCRequest.params as EchoParams).message
         }`,
       })
@@ -146,7 +146,7 @@ describe("JSONRPCServerAndClient", () => {
         return new Promise<void>((givenResolve) => (resolve = givenResolve));
       });
 
-      promise = serverAndClient1.request("hang");
+      promise = serverAndClient1.request("hang", undefined);
     });
 
     describe("rejecting all pending requests", () => {

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -55,31 +55,31 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
 
   request(
     method: string,
-    params?: JSONRPCParams,
-    clientParams?: ClientParams
+    params: JSONRPCParams,
+    clientParams: ClientParams
   ): PromiseLike<any> {
     return this.client.request(method, params, clientParams);
   }
 
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest,
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse>;
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest[],
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse[]>;
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest | JSONRPCRequest[],
-    clientParams?: ClientParams
+    clientParams: ClientParams
   ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> {
     return this.client.requestAdvanced(jsonRPCRequest as any, clientParams);
   }
 
   notify(
     method: string,
-    params?: JSONRPCParams,
-    clientParams?: ClientParams
+    params: JSONRPCParams,
+    clientParams: ClientParams
   ): void {
     this.client.notify(method, params, clientParams);
   }
@@ -90,8 +90,8 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
 
   async receiveAndSend(
     payload: any,
-    serverParams?: ServerParams,
-    clientParams?: ClientParams
+    serverParams: ServerParams,
+    clientParams: ClientParams
   ): Promise<void> {
     if (isJSONRPCResponse(payload) || isJSONRPCResponses(payload)) {
       this.client.receive(payload);

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -420,7 +420,7 @@ describe("JSONRPCServer", () => {
           (
             next: JSONRPCServerMiddlewareNext<ServerParams>,
             request: JSONRPCRequest,
-            serverParams: ServerParams | undefined
+            serverParams: ServerParams
           ): PromiseLike<JSONRPCResponse | null> => {
             middlewareCalled = true;
             return next(request, serverParams).then((result) => {

--- a/src/server.spec.ts
+++ b/src/server.spec.ts
@@ -85,7 +85,9 @@ describe("JSONRPCServer", () => {
             }),
             { userID: "bar" }
           )
-          .then((givenResponse: JSONRPCResponse) => (response = givenResponse));
+          .then(
+            (givenResponse) => (response = givenResponse as JSONRPCResponse)
+          );
       });
 
       it("should echo the text with the user ID", () => {
@@ -623,7 +625,7 @@ describe("JSONRPCServer", () => {
         server.applyMiddleware(async (next, request, serverParams) => {
           try {
             return await next(request, serverParams);
-          } catch (error) {
+          } catch (error: any) {
             return createJSONRPCErrorResponse(
               request.id!,
               error.code || JSONRPCErrorCode.InternalError,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import {
   JSONRPCRequest,
   JSONRPCResponse,
   JSONRPCParams,
-  JSONRPC,
   JSONRPCID,
   JSONRPCErrorCode,
   JSONRPCErrorException,
@@ -17,7 +16,7 @@ import {
 import { DefaultErrorCode } from "./internal";
 
 export type SimpleJSONRPCMethod<ServerParams = void> = (
-  params: Partial<JSONRPCParams> | undefined,
+  params: JSONRPCParams,
   serverParams: ServerParams | undefined
 ) => any;
 export type JSONRPCMethod<ServerParams = void> = (
@@ -90,7 +89,7 @@ export class JSONRPCServer<ServerParams = void> {
   ): JSONRPCMethod<ServerParams> {
     return (
       request: JSONRPCRequest,
-      serverParams: ServerParams
+      serverParams: ServerParams | undefined
     ): JSONRPCResponsePromise => {
       const response = method(request.params, serverParams);
       return Promise.resolve(response).then((result: any) =>

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,22 +17,22 @@ import { DefaultErrorCode } from "./internal";
 
 export type SimpleJSONRPCMethod<ServerParams = void> = (
   params: JSONRPCParams,
-  serverParams: ServerParams | undefined
+  serverParams: ServerParams
 ) => any;
 export type JSONRPCMethod<ServerParams = void> = (
   request: JSONRPCRequest,
-  serverParams: ServerParams | undefined
+  serverParams: ServerParams
 ) => JSONRPCResponsePromise;
 export type JSONRPCResponsePromise = PromiseLike<JSONRPCResponse | null>;
 
 export type JSONRPCServerMiddlewareNext<ServerParams> = (
   request: JSONRPCRequest,
-  serverParams: ServerParams | undefined
+  serverParams: ServerParams
 ) => JSONRPCResponsePromise;
 export type JSONRPCServerMiddleware<ServerParams> = (
   next: JSONRPCServerMiddlewareNext<ServerParams>,
   request: JSONRPCRequest,
-  serverParams: ServerParams | undefined
+  serverParams: ServerParams
 ) => JSONRPCResponsePromise;
 
 type NameToMethodDictionary<ServerParams> = {
@@ -89,7 +89,7 @@ export class JSONRPCServer<ServerParams = void> {
   ): JSONRPCMethod<ServerParams> {
     return (
       request: JSONRPCRequest,
-      serverParams: ServerParams | undefined
+      serverParams: ServerParams
     ): JSONRPCResponsePromise => {
       const response = method(request.params, serverParams);
       return Promise.resolve(response).then((result: any) =>
@@ -212,7 +212,7 @@ export class JSONRPCServer<ServerParams = void> {
     return (
       next: JSONRPCServerMiddlewareNext<ServerParams>,
       request: JSONRPCRequest,
-      serverParams: ServerParams | undefined
+      serverParams: ServerParams
     ): JSONRPCResponsePromise => {
       return prevMiddleware(
         (request, serverParams) => nextMiddleware(next, request, serverParams),
@@ -229,7 +229,7 @@ export class JSONRPCServer<ServerParams = void> {
   ): JSONRPCResponsePromise {
     const callMethod: JSONRPCServerMiddlewareNext<ServerParams> = (
       request: JSONRPCRequest,
-      serverParams: ServerParams | undefined
+      serverParams: ServerParams
     ): JSONRPCResponsePromise => {
       if (method) {
         return method(request, serverParams);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,11 @@
 {
   "compilerOptions": {
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "strictNullChecks": true,
+    "strict": true,
     "outDir": "dist",
     "declaration": true,
     "module": "commonjs",
     "target": "es5",
-    "lib": [
-      "es5",
-      "es6"
-    ]
+    "lib": ["es5", "es6"]
   },
-  "include": [
-    "./src/**/*.ts"
-  ]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
It doesn't change any runtime behavior, but it might break backward compatibility on type check for `ServerParams` and `ClientParams`. A quick fix is to make them `void` or `ServerParams | void` so that they won't be a required param when calling `request`, for example.

Close #41 