### PR TITLE
Update README.md with clarification for Client Auth Params

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ client.notify("log", { message: "Hello, World!" });
 Just like `JSONRPCServer`, you can inject custom params to `JSONRPCClient` too:
 
 ```javascript
-class AuthToken {
-  public token: string;
+interface AuthToken {
+  token: string;
 }
 
 const client = new JSONRPCClient<AuthToken>(

--- a/README.md
+++ b/README.md
@@ -176,7 +176,11 @@ client.notify("log", { message: "Hello, World!" });
 Just like `JSONRPCServer`, you can inject custom params to `JSONRPCClient` too:
 
 ```javascript
-const client = new JSONRPCClient(
+class AuthToken {
+  public token: string;
+}
+
+const client = new JSONRPCClient<AuthToken>(
   // It can also take a custom parameter as the second parameter.
   (jsonRPCRequest, { token }) =>
     fetch("http://localhost/json-rpc", {


### PR DESCRIPTION
Added a small clarification for fellow devs.

I'm probably dumb but I found the default `ClientParams = void` confusing and thought this small tweak to the example would be helpful for future confused devs :)

Tried to keep it as simple as possible!