### PR TITLE
Add generic type parameter for client response types

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -22,15 +22,15 @@ type Resolve = (response: JSONRPCResponse) => void;
 type IDToDeferredMap = Map<JSONRPCID, Resolve>;
 
 export interface JSONRPCRequester<ClientParams> {
-  request(
+  request<T = any>(
     method: string,
     params?: JSONRPCParams,
     clientParams?: ClientParams
-  ): PromiseLike<any>;
-  requestAdvanced(
+  ): PromiseLike<T>;
+  requestAdvanced<T = any>(
     request: JSONRPCRequest,
     clientParams?: ClientParams
-  ): PromiseLike<JSONRPCResponse>;
+  ): PromiseLike<JSONRPCResponse<T>>;
   requestAdvanced(
     request: JSONRPCRequest[],
     clientParams?: ClientParams
@@ -122,23 +122,23 @@ export class JSONRPCClient<ClientParams = void>
     };
   }
 
-  request(
+  request<T = any>(
     method: string,
     params: JSONRPCParams,
     clientParams: ClientParams
-  ): PromiseLike<any> {
-    return this.requestWithID(method, params, clientParams, this._createID());
+  ): PromiseLike<T> {
+    return this.requestWithID<T>(method, params, clientParams, this._createID());
   }
 
-  private async requestWithID(
+  private async requestWithID<T = any>(
     method: string,
     params: JSONRPCParams | undefined,
     clientParams: ClientParams,
     id: JSONRPCID
-  ): Promise<any> {
+  ): Promise<T> {
     const request: JSONRPCRequest = createJSONRPCRequest(id, method, params);
 
-    const response: JSONRPCResponse = await this.requestAdvanced(
+    const response: JSONRPCResponse<T> = await this.requestAdvanced(
       request,
       clientParams
     );
@@ -157,10 +157,10 @@ export class JSONRPCClient<ClientParams = void>
     }
   }
 
-  requestAdvanced(
+  requestAdvanced<T = any>(
     request: JSONRPCRequest,
     clientParams: ClientParams
-  ): PromiseLike<JSONRPCResponse>;
+  ): PromiseLike<JSONRPCResponse<T>>;
   requestAdvanced(
     request: JSONRPCRequest[],
     clientParams: ClientParams

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,12 +14,12 @@ export interface JSONRPCRequest {
   id?: JSONRPCID;
 }
 
-export type JSONRPCResponse = JSONRPCSuccessResponse | JSONRPCErrorResponse;
+export type JSONRPCResponse<T = any> = JSONRPCSuccessResponse<T> | JSONRPCErrorResponse;
 
-export interface JSONRPCSuccessResponse {
+export interface JSONRPCSuccessResponse<T = any> {
   jsonrpc: JSONRPC;
   id: JSONRPCID;
-  result: any;
+  result: T;
   error?: undefined;
 }
 
@@ -32,6 +32,8 @@ export interface JSONRPCErrorResponse {
 
 export const isJSONRPCRequest = (payload: any): payload is JSONRPCRequest => {
   return (
+    payload != null &&
+    typeof payload === "object" &&
     payload.jsonrpc === JSONRPC &&
     payload.method !== undefined &&
     payload.result === undefined &&
@@ -47,6 +49,8 @@ export const isJSONRPCRequests = (
 
 export const isJSONRPCResponse = (payload: any): payload is JSONRPCResponse => {
   return (
+    payload != null &&
+    typeof payload === "object" &&
     payload.jsonrpc === JSONRPC &&
     payload.id !== undefined &&
     (payload.result !== undefined || payload.error !== undefined)

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -57,18 +57,18 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
     return this.client.timeout(delay);
   }
 
-  request(
+  request<T = any>(
     method: string,
     params: JSONRPCParams,
     clientParams: ClientParams
-  ): PromiseLike<any> {
-    return this.client.request(method, params, clientParams);
+  ): PromiseLike<T> {
+    return this.client.request<T>(method, params, clientParams);
   }
 
-  requestAdvanced(
+  requestAdvanced<T = any>(
     jsonRPCRequest: JSONRPCRequest,
     clientParams: ClientParams
-  ): PromiseLike<JSONRPCResponse>;
+  ): PromiseLike<JSONRPCResponse<T>>;
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest[],
     clientParams: ClientParams


### PR DESCRIPTION
The `client.request()` & `client.requestAdvanced()` methods currently return `PromiseLike<any>`, discarding type information at every call site. This forces consumers to manually cast results:
```ts
const user = await client.requestAdvanced({ method: "Users.GetUser", ... }) as JSONRPCResponse<User>;
```

This PR adds an optional generic parameter (defaulting to `any`) to the response types and all request methods, so type information can propagate through the entire request-response cycle.

This change is about typing raw `request()` / `requestAdvanced()` calls directly, without relying on the `TypedJSONRPCClient` wrapper or casting.

```ts
const user = await client.request<User>("Users.GetUser", ...);
// ----
const user = await client.requestAdvanced<User>({ method: "User.getUser", ... });
```

Also tightened `isJSONRPCRequest` and `isJSONRPCResponse` with a null/object type guard to prevent runtime errors when null or primitive values are passed. Since they are a public functions, there's no guarantee that consumers pass only objects.

Fully backward compatible - all generics default to `any`, so existing code needs no changes.
