### PR TITLE
Support AbortController

### DIFF
--- a/src/client.spec.ts
+++ b/src/client.spec.ts
@@ -17,6 +17,12 @@ interface ClientParams {
   token: string;
 }
 
+const expectToBeRejected = (promise: PromiseLike<any>): PromiseLike<void> =>
+  promise.then(
+    () => Promise.reject(new Error("Expected to reject")),
+    () => undefined
+  );
+
 describe("JSONRPCClient", () => {
   let client: JSONRPCClient<ClientParams>;
 
@@ -25,19 +31,24 @@ describe("JSONRPCClient", () => {
   let lastClientParams: ClientParams | undefined;
   let resolve: (() => void) | undefined;
   let reject: ((error: any) => void) | undefined;
+  let lastAbortSignal: AbortSignal | undefined;
 
   beforeEach(() => {
     id = 0;
     lastRequest = undefined;
+    lastClientParams = undefined;
+    lastAbortSignal = undefined;
     resolve = undefined;
     reject = undefined;
 
     const send = (
       request: JSONRPCRequest,
-      clientParams: ClientParams
+      clientParams: ClientParams,
+      abortSignal?: AbortSignal
     ): PromiseLike<void> => {
       lastRequest = request;
       lastClientParams = clientParams;
+      lastAbortSignal = abortSignal;
       return new Promise((givenResolve, givenReject) => {
         resolve = givenResolve;
         reject = givenReject;
@@ -333,10 +344,23 @@ describe("JSONRPCClient", () => {
       });
 
       it("should reject", () => {
-        return promise.then(
-          () => Promise.reject(new Error("Expected to fail")),
-          () => undefined
+        return expectToBeRejected(promise);
+      });
+
+      it("should reject with a proper timeout error", async () => {
+        let error;
+        try {
+          await promise;
+          throw new Error("Expected to fail");
+        } catch (e) {
+          error = e;
+        }
+
+        expect(error).to.be.instanceOf(JSONRPCErrorException);
+        expect((error as JSONRPCErrorException).message).to.equal(
+          "Request timeout"
         );
+        expect((error as JSONRPCErrorException).code).to.equal(0);
       });
     });
 
@@ -482,6 +506,141 @@ describe("JSONRPCClient", () => {
 
     it("should pass the client params to send function", () => {
       expect(lastClientParams).to.deep.equal(expected);
+    });
+  });
+
+  describe("abort signal", () => {
+    describe("request", () => {
+      it("should pass abortSignal to send", () => {
+        const ac = new AbortController();
+        client.request("foo", ["bar"], { token: "" }, ac);
+        expect(lastAbortSignal).to.equal(ac.signal);
+      });
+
+      it("should have aborted signal after abort() is called", () => {
+        const ac = new AbortController();
+        client.request("foo", ["bar"], { token: "" }, ac);
+        ac.abort();
+        expect(lastAbortSignal!.aborted).to.be.true;
+      });
+    });
+
+    describe("requestAdvanced", () => {
+      it("should pass abortSignal to send", () => {
+        const ac = new AbortController();
+        client.requestAdvanced(
+          { jsonrpc: JSONRPC, id: ++id, method: "foo" },
+          { token: "" },
+          ac
+        );
+        expect(lastAbortSignal).to.equal(ac.signal);
+      });
+
+      it("should have aborted signal after abort() is called", () => {
+        const ac = new AbortController();
+        client.requestAdvanced(
+          { jsonrpc: JSONRPC, id: ++id, method: "foo" },
+          { token: "" },
+          ac
+        );
+        ac.abort();
+        expect(lastAbortSignal!.aborted).to.be.true;
+      });
+    });
+
+    describe("notify", () => {
+      it("should pass abortSignal to send", () => {
+        const ac = new AbortController();
+        client.notify("foo", ["bar"], { token: "" }, ac.signal);
+        expect(lastAbortSignal).to.equal(ac.signal);
+      });
+
+      it("should have aborted signal after abort() is called", () => {
+        const ac = new AbortController();
+        client.notify("foo", ["bar"], { token: "" }, ac.signal);
+        ac.abort();
+        expect(lastAbortSignal!.aborted).to.be.true;
+      });
+    });
+  });
+
+  describe("timeout abort signal", () => {
+    let fakeTimers: sinon.SinonFakeTimers;
+    let delay: number;
+
+    beforeEach(() => {
+      fakeTimers = sinon.useFakeTimers();
+      delay = 1000;
+    });
+
+    afterEach(() => {
+      fakeTimers.restore();
+    });
+
+    describe("aborted by timeout via default controller", () => {
+      it("should abort the internal controller when timeout fires", () => {
+        const promise = client.timeout(delay).request("foo");
+        resolve!();
+
+        expect(lastAbortSignal!.aborted).to.be.false;
+
+        fakeTimers.tick(delay);
+
+        expect(lastAbortSignal!.aborted).to.be.true;
+
+        return expectToBeRejected(promise);
+      });
+    });
+
+    describe("aborted by timeout via external controller", () => {
+      it("should abort the external controller when timeout fires", () => {
+        const ac = new AbortController();
+        const promise = client
+          .timeout(delay)
+          .request("foo", undefined, undefined, ac);
+        resolve!();
+
+        expect(lastAbortSignal).to.equal(ac.signal);
+        expect(lastAbortSignal!.aborted).to.be.false;
+
+        fakeTimers.tick(delay);
+
+        expect(ac.signal.aborted).to.be.true;
+
+        return expectToBeRejected(promise);
+      });
+    });
+
+    describe("aborted by external code before timeout", () => {
+      it("should clear timeout and reject when external abort is called before timeout fires", () => {
+        const ac = new AbortController();
+        let error: any;
+        const promise = client
+          .timeout(delay)
+          .request("foo", undefined, undefined, ac)
+          .then(
+            () => undefined,
+            (e) => (error = e)
+          );
+        resolve!();
+
+        // Abort externally before timeout
+        ac.abort("Cancelled by user");
+        expect(ac.signal.aborted).to.be.true;
+
+        // Complete the in-flight request — the .aborted guard will reject it
+        client.receive({
+          jsonrpc: JSONRPC,
+          id: lastRequest!.id!,
+          result: "bar",
+        });
+
+        return promise.then(() => {
+          expect(error).to.be.instanceOf(JSONRPCErrorException);
+          expect(error.message).to.equal("Cancelled by user");
+          expect(error.code).to.equal(0);
+        });
+      });
     });
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,8 @@ import { DefaultErrorCode } from "./internal";
 
 export type SendRequest<ClientParams> = (
   payload: any,
-  clientParams: ClientParams
+  clientParams: ClientParams,
+  abortSignal?: AbortSignal
 ) => PromiseLike<void> | void;
 export type CreateID = () => JSONRPCID;
 
@@ -25,15 +26,18 @@ export interface JSONRPCRequester<ClientParams> {
   request(
     method: string,
     params?: JSONRPCParams,
-    clientParams?: ClientParams
+    clientParams?: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<any>;
   requestAdvanced(
     request: JSONRPCRequest,
-    clientParams?: ClientParams
+    clientParams?: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<JSONRPCResponse>;
   requestAdvanced(
     request: JSONRPCRequest[],
-    clientParams?: ClientParams
+    clientParams?: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<JSONRPCResponse[]>;
 }
 
@@ -68,21 +72,48 @@ export class JSONRPCClient<ClientParams = void>
   ): JSONRPCRequester<ClientParams> {
     const timeoutRequest = (
       ids: JSONRPCID[],
-      request: () => PromiseLike<any>
+      request: () => PromiseLike<any>,
+      abortController: AbortController
     ) => {
       const timeoutID = setTimeout(() => {
         ids.forEach((id) => {
           const resolve: Resolve | undefined = this.idToResolveMap.get(id);
           if (resolve) {
             this.idToResolveMap.delete(id);
-            resolve(overrideCreateJSONRPCErrorResponse(id));
+            const errResp = overrideCreateJSONRPCErrorResponse(id);
+            abortController.abort(errResp);
+            resolve(errResp);
           }
         });
       }, delay);
 
+      // The 'abort' event is not supported by:
+      // - browsers < 2018
+      // - nodejs < 14.17
+      // @ts-ignore
+      abortController.signal.addEventListener?.(
+        "abort",
+        () => clearTimeout(timeoutID),
+        { once: true }
+      );
+
       return request().then(
         (result) => {
           clearTimeout(timeoutID);
+          if (abortController.signal.aborted) {
+            // If result already has an error (timeout fired and resolved via the map),
+            // return it as-is rather than replacing with a generic abort error.
+            if (result && typeof result === "object" && "error" in result) {
+              return result;
+            }
+            const error =
+              typeof abortController.signal.reason === "string"
+                ? abortController.signal.reason
+                : "Aborted";
+            return Promise.reject(
+              new JSONRPCErrorException(error, DefaultErrorCode)
+            );
+          }
           return result;
         },
         (error) => {
@@ -94,13 +125,23 @@ export class JSONRPCClient<ClientParams = void>
 
     const requestAdvanced = (
       request: JSONRPCRequest | JSONRPCRequest[],
-      clientParams: ClientParams
+      clientParams: ClientParams,
+      abortController?: AbortController
     ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> => {
       const ids: JSONRPCID[] = (!Array.isArray(request) ? [request] : request)
         .map((request) => request.id)
         .filter(isDefinedAndNonNull);
-      return timeoutRequest(ids, () =>
-        this.requestAdvanced(request as any, clientParams)
+
+      const abortControllerRef = abortController ?? new AbortController();
+      return timeoutRequest(
+        ids,
+        () =>
+          this.requestAdvanced(
+            request as any,
+            clientParams,
+            abortControllerRef
+          ),
+        abortControllerRef
       );
     };
 
@@ -108,39 +149,62 @@ export class JSONRPCClient<ClientParams = void>
       request: (
         method: string,
         params: JSONRPCParams,
-        clientParams: ClientParams
+        clientParams: ClientParams,
+        abortController?: AbortController
       ): PromiseLike<any> => {
         const id: JSONRPCID = this._createID();
-        return timeoutRequest([id], () =>
-          this.requestWithID(method, params, clientParams, id)
+        const abortControllerRef = abortController ?? new AbortController();
+        return timeoutRequest(
+          [id],
+          () =>
+            this.requestWithID(
+              method,
+              params,
+              clientParams,
+              id,
+              abortControllerRef
+            ),
+          abortControllerRef
         );
       },
       requestAdvanced: (
-        request: any,
-        clientParams: ClientParams
-      ): PromiseLike<any> => requestAdvanced(request, clientParams),
+        request: JSONRPCRequest | JSONRPCRequest[],
+        clientParams: ClientParams,
+        abortController?: AbortController
+      ): PromiseLike<any> => {
+        return requestAdvanced(request, clientParams, abortController);
+      },
     };
   }
 
   request(
     method: string,
     params: JSONRPCParams,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<any> {
-    return this.requestWithID(method, params, clientParams, this._createID());
+    return this.requestWithID(
+      method,
+      params,
+      clientParams,
+      this._createID(),
+      abortController
+    );
   }
 
   private async requestWithID(
     method: string,
     params: JSONRPCParams | undefined,
     clientParams: ClientParams,
-    id: JSONRPCID
+    id: JSONRPCID,
+    abortController?: AbortController
   ): Promise<any> {
     const request: JSONRPCRequest = createJSONRPCRequest(id, method, params);
 
     const response: JSONRPCResponse = await this.requestAdvanced(
       request,
-      clientParams
+      clientParams,
+      abortController
     );
     if (response.result !== undefined && !response.error) {
       return response.result;
@@ -159,15 +223,18 @@ export class JSONRPCClient<ClientParams = void>
 
   requestAdvanced(
     request: JSONRPCRequest,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<JSONRPCResponse>;
   requestAdvanced(
     request: JSONRPCRequest[],
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<JSONRPCResponse[]>;
   requestAdvanced(
     requests: JSONRPCRequest | JSONRPCRequest[],
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController
   ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> {
     const areRequestsOriginallyArray = Array.isArray(requests);
     if (!Array.isArray(requests)) {
@@ -194,7 +261,8 @@ export class JSONRPCClient<ClientParams = void>
 
     return this.send(
       areRequestsOriginallyArray ? requests : requests[0],
-      clientParams
+      clientParams,
+      abortController?.signal
     ).then(
       () => promise,
       (error) => {
@@ -215,15 +283,19 @@ export class JSONRPCClient<ClientParams = void>
   notify(
     method: string,
     params: JSONRPCParams,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortSignal?: AbortSignal
   ): void {
     const request: JSONRPCRequest = createJSONRPCNotification(method, params);
-
-    this.send(request, clientParams).then(undefined, () => undefined);
+    void this.send(request, clientParams, abortSignal);
   }
 
-  async send(payload: any, clientParams: ClientParams): Promise<void> {
-    return this._send(payload, clientParams);
+  async send(
+    payload: any,
+    clientParams: ClientParams,
+    abortSignal?: AbortSignal
+  ): Promise<void> {
+    return this._send(payload, clientParams, abortSignal);
   }
 
   rejectAllPendingRequests(message: string): void {

--- a/src/server-and-client.ts
+++ b/src/server-and-client.ts
@@ -60,32 +60,37 @@ export class JSONRPCServerAndClient<ServerParams = void, ClientParams = void> {
   request(
     method: string,
     params: JSONRPCParams,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController,
   ): PromiseLike<any> {
-    return this.client.request(method, params, clientParams);
+    return this.client.request(method, params, clientParams, abortController);
   }
 
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController,
   ): PromiseLike<JSONRPCResponse>;
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest[],
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController,
   ): PromiseLike<JSONRPCResponse[]>;
   requestAdvanced(
     jsonRPCRequest: JSONRPCRequest | JSONRPCRequest[],
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortController?: AbortController,
   ): PromiseLike<JSONRPCResponse | JSONRPCResponse[]> {
-    return this.client.requestAdvanced(jsonRPCRequest as any, clientParams);
+    return this.client.requestAdvanced(jsonRPCRequest as any, clientParams, abortController);
   }
 
   notify(
     method: string,
     params: JSONRPCParams,
-    clientParams: ClientParams
+    clientParams: ClientParams,
+    abortSignal?: AbortSignal,
   ): void {
-    this.client.notify(method, params, clientParams);
+    this.client.notify(method, params, clientParams, abortSignal);
   }
 
   rejectAllPendingRequests(message: string): void {


### PR DESCRIPTION
Add `AbortController` / `AbortSignal` to JSONRPCClient so transport calls can be cancelled on timeout or by caller request.

**Reasons?**

Timeouts waste resources.`client.timeout(1000).request("slow")` fires the timeout but the underlying fetch keeps running. Now `_send` receives the abort signal and can stop immediately.

No way to cancel a single request. Only `rejectAllPendingRequests()` existed, which nukes everything. Now pass an `AbortController` to cancel one specific request.

Fully backward compatible - all added parameters are optional.